### PR TITLE
Fix conda python reference issue (showed up in yarn), add example with standalone mode, make logging super verbose

### DIFF
--- a/Coffee+Boat+Sample.ipynb
+++ b/Coffee+Boat+Sample.ipynb
@@ -193,65 +193,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "          <script src=\"/static/components/requirejs/require.js\"></script>\n",
-       "          <script>\n",
-       "            requirejs.config({\n",
-       "              paths: {\n",
-       "                base: '/static/base',\n",
-       "              },\n",
-       "            });\n",
-       "          </script>\n",
-       "          "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "fatal: destination path 'coffee_boat' already exists and is not an empty directory.\n",
-      "remote: Counting objects: 12, done.\u001b[K\n",
-      "remote: Compressing objects: 100% (8/8), done.\u001b[K\n",
-      "remote: Total 12 (delta 5), reused 11 (delta 4), pack-reused 0\u001b[K\n",
-      "Unpacking objects: 100% (12/12), done.\n",
-      "From https://github.com/holdenk/coffee_boat\n",
-      "   6f1700a..222a903  improve-logging-on-fail -> origin/improve-logging-on-fail\n",
-      "Updating 6f1700a..222a903\n",
-      "Fast-forward\n",
-      " coffee_boat/captain.py | 21 \u001b[32m+++++++++\u001b[m\u001b[31m------------\u001b[m\n",
-      " 1 file changed, 9 insertions(+), 12 deletions(-)\n",
-      "Already on 'improve-logging-on-fail'\n",
-      "Your branch is up-to-date with 'origin/improve-logging-on-fail'.\n",
-      "Already up-to-date.\n",
-      "Obtaining file:///content/datalab/notebooks/coffee_boat\n",
-      "Installing collected packages: coffee-boat\n",
-      "  Found existing installation: coffee-boat 0.0.1\n",
-      "    Can't uninstall 'coffee-boat'. No files were found to uninstall.\n",
-      "  Running setup.py develop for coffee-boat\n",
-      "Successfully installed coffee-boat\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Clone cofee boat in\n",
     "# \"Production\":\n",
-    "# !pip install --upgrade git+https://github.com/nteract/coffee_boat.git\n",
+    "!pip install --upgrade git+https://github.com/nteract/coffee_boat.git\n",
     "# Dev:\n",
-    "!git clone git+https://github.com/holdenk/coffee_boat.git; cd coffee_boat && git pull && git checkout improve-logging-on-fail && git pull && pip install --upgrade -e .\n"
+    "# !git clone git+https://github.com/holdenk/coffee_boat.git; cd coffee_boat && git pull && git checkout improve-logging-on-fail && git pull && pip install --upgrade -e .\n"
    ]
   },
   {

--- a/Coffee+Boat+Sample.ipynb
+++ b/Coffee+Boat+Sample.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
@@ -32,18 +32,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "rm: cannot remove '/usr/lib/spark/python/pyspark/shell.py': No such file or directory\r\n"
+      "rm: cannot remove '/usr/lib/spark/python/pyspark/shell.py': No such file or directory\r\n",
+      "No startup script, yay!\r\n"
      ]
     }
    ],
    "source": [
     "# If your working in datalab inside of dataproc they auto start PySpark, which is great -- except we need to kill it first\n",
-    "!rm /usr/lib/spark/python/pyspark/shell.py && echo \"Please restart your kernel, PySpark was already loaded :(\""
+    "!rm /usr/lib/spark/python/pyspark/shell.py && echo \"Please restart your kernel, PySpark was already loaded :(\" || echo \"No startup script, yay!\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -76,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
@@ -106,10 +107,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Collecting pyspark\n",
-      "Requirement already satisfied: py4j==0.10.4 in /usr/local/lib/python2.7/dist-packages (from pyspark)\n",
-      "Installing collected packages: pyspark\n",
-      "Successfully installed pyspark-2.2.1\n"
+      "Requirement already satisfied: pyspark in /usr/local/lib/python2.7/dist-packages\r\n",
+      "Requirement already satisfied: py4j==0.10.4 in /usr/local/lib/python2.7/dist-packages (from pyspark)\r\n"
      ]
     }
    ],
@@ -120,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
@@ -161,7 +160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
@@ -194,7 +193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
@@ -224,71 +223,40 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Collecting git+https://github.com/holdenk/coffee_boat.git\n",
-      "  Cloning https://github.com/holdenk/coffee_boat.git to /tmp/pip-hSq1gt-build\n",
-      "  Requirement already satisfied (use --upgrade to upgrade): coffee-boat==0.0.1 from git+https://github.com/holdenk/coffee_boat.git in ./coffee_boat\n"
+      "fatal: destination path 'coffee_boat' already exists and is not an empty directory.\n",
+      "remote: Counting objects: 12, done.\u001b[K\n",
+      "remote: Compressing objects: 100% (8/8), done.\u001b[K\n",
+      "remote: Total 12 (delta 5), reused 11 (delta 4), pack-reused 0\u001b[K\n",
+      "Unpacking objects: 100% (12/12), done.\n",
+      "From https://github.com/holdenk/coffee_boat\n",
+      "   6f1700a..222a903  improve-logging-on-fail -> origin/improve-logging-on-fail\n",
+      "Updating 6f1700a..222a903\n",
+      "Fast-forward\n",
+      " coffee_boat/captain.py | 21 \u001b[32m+++++++++\u001b[m\u001b[31m------------\u001b[m\n",
+      " 1 file changed, 9 insertions(+), 12 deletions(-)\n",
+      "Already on 'improve-logging-on-fail'\n",
+      "Your branch is up-to-date with 'origin/improve-logging-on-fail'.\n",
+      "Already up-to-date.\n",
+      "Obtaining file:///content/datalab/notebooks/coffee_boat\n",
+      "Installing collected packages: coffee-boat\n",
+      "  Found existing installation: coffee-boat 0.0.1\n",
+      "    Can't uninstall 'coffee-boat'. No files were found to uninstall.\n",
+      "  Running setup.py develop for coffee-boat\n",
+      "Successfully installed coffee-boat\n"
      ]
     }
    ],
    "source": [
     "# Clone cofee boat in\n",
-    "!pip install git+https://github.com/holdenk/coffee_boat.git"
+    "# \"Production\":\n",
+    "# !pip install --upgrade git+https://github.com/nteract/coffee_boat.git\n",
+    "# Dev:\n",
+    "!git clone git+https://github.com/holdenk/coffee_boat.git; cd coffee_boat && git pull && git checkout improve-logging-on-fail && git pull && pip install --upgrade -e .\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "          <script src=\"/static/components/requirejs/require.js\"></script>\n",
-       "          <script>\n",
-       "            requirejs.config({\n",
-       "              paths: {\n",
-       "                base: '/static/base',\n",
-       "              },\n",
-       "            });\n",
-       "          </script>\n",
-       "          "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "remote: Counting objects: 71, done.\u001b[K\n",
-      "remote: Compressing objects: 100% (40/40), done.\u001b[K\n",
-      "remote: Total 71 (delta 34), reused 68 (delta 31), pack-reused 0\u001b[K\n",
-      "Unpacking objects: 100% (71/71), done.\n",
-      "From https://github.com/holdenk/coffee_boat\n",
-      "   341e518..1c0352c  expirement -> origin/expirement\n",
-      "   37532d7..a1312be  master     -> origin/master\n",
-      "Updating 341e518..1c0352c\n",
-      "Fast-forward\n",
-      " Coffee+Boat+Sample.ipynb | 1187 \u001b[32m++++++++++++++++++++++++++++++++++++++++++++++\u001b[m\n",
-      " 1 file changed, 1187 insertions(+)\n",
-      " create mode 100644 Coffee+Boat+Sample.ipynb\n"
-     ]
-    }
-   ],
-   "source": [
-    "!cd coffee_boat; git pull"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -321,7 +289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -346,14 +314,6 @@
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Downloading conda from https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh to /tmp/coffee_boat_tmp_6TQBrI\n",
-      "Running conda setup....\n"
-     ]
     }
    ],
    "source": [
@@ -362,7 +322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -396,7 +356,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
@@ -430,7 +390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -462,7 +422,7 @@
        "''"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -473,7 +433,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {
     "collapsed": false
    },
@@ -498,6 +458,14 @@
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Adding package to requirements. Remember to launch coffee boat beforestarting SparkContext.\n",
+      "Installing package locally\n"
+     ]
     }
    ],
    "source": [
@@ -506,7 +474,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
@@ -539,6 +507,117 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "          <script src=\"/static/components/requirejs/require.js\"></script>\n",
+       "          <script>\n",
+       "            requirejs.config({\n",
+       "              paths: {\n",
+       "                base: '/static/base',\n",
+       "              },\n",
+       "            });\n",
+       "          </script>\n",
+       "          "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "root      5492  0.0  0.0   4508   792 pts/0    Ss+  06:10   0:00 /bin/sh -c ps aux |grep spark\r\n",
+      "root      5494  0.0  0.0  12944   960 pts/0    S+   06:10   0:00 grep spark\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Verify we aren't yet running PySpark\n",
+    "if 'sc' in globals():\n",
+    "  sc.stop\n",
+    "!ps aux |grep spark"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "          <script src=\"/static/components/requirejs/require.js\"></script>\n",
+       "          <script>\n",
+       "            requirejs.config({\n",
+       "              paths: {\n",
+       "                base: '/static/base',\n",
+       "              },\n",
+       "            });\n",
+       "          </script>\n",
+       "          "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading conda from https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh to /tmp/coffee_boat_tmp_BX66Ae\n",
+      "Running conda setup....\n",
+      "Writing package spec to /tmp/coffee_boat_tmp_BX66Ae/tmp6BNyKn.\n",
+      "Creating conda env\n",
+      "Packaging conda env\n",
+      "Using runner script\n",
+      "#!/bin/bash\n",
+      "touch setup.lock # TODO: work with this\n",
+      "echo \"Kicking off python runner coffee_boat_auto059d3708c86a4cabb4b5ebb049e308c1.zip\" > coffee_log.txt\n",
+      "echo \"pwd looks like:\" >> coffee_log.txt\n",
+      "ls >> coffee_log.txt\n",
+      "echo \"k\" >> coffee_log.txt\n",
+      "if [ -f coffee_boat_auto059d3708c86a4cabb4b5ebb049e308c1.zip ];\n",
+      "then\n",
+      "    echo \"Running setup\" >> coffee_log.txt\n",
+      "    unzip coffee_boat_auto059d3708c86a4cabb4b5ebb049e308c1.zip &>> coffee_log.txt && rm coffee_boat_auto059d3708c86a4cabb4b5ebb049e308c1.zip &>> coffee_log.txt\n",
+      "    # Since Conda isn't really fully relocatable...\n",
+      "    echo \"Rewriting conda and pip python paths...\" >> coffee_log.txt\n",
+      "    sed -i -e \"1s@.*@\\#\\!./tmp/coffee_boat_tmp_BX66Ae/auto059d3708c86a4cabb4b5ebb049e308c1/bin/python@\" ./tmp/coffee_boat_tmp_BX66Ae/auto059d3708c86a4cabb4b5ebb049e308c1/bin/conda >> coffee_log.txt\n",
+      "    sed -i -e \"1s@.*@\\#\\!./tmp/coffee_boat_tmp_BX66Ae/auto059d3708c86a4cabb4b5ebb049e308c1/bin/python@\" ./tmp/coffee_boat_tmp_BX66Ae/auto059d3708c86a4cabb4b5ebb049e308c1/bin/pip >> coffee_log.txt\n",
+      "fi\n",
+      "cat magicCoffeeReq* > mini_req.txt &> /dev/null || true\n",
+      "echo \"pip install\" >> coffee_log.txt\n",
+      "./tmp/coffee_boat_tmp_BX66Ae/auto059d3708c86a4cabb4b5ebb049e308c1/bin/pip install -r mini_req.txt &>> coffee_log.txt\n",
+      "export PATH=./tmp/coffee_boat_tmp_BX66Ae/auto059d3708c86a4cabb4b5ebb049e308c1/bin:$PATH\n",
+      "./tmp/coffee_boat_tmp_BX66Ae/auto059d3708c86a4cabb4b5ebb049e308c1/bin/python \"$@\" || cat coffee_log.txt 1>&2 \n",
+      "using --files /tmp/coffee_boat_tmp_BX66Ae/coffee_boat_auto059d3708c86a4cabb4b5ebb049e308c1.zip,/tmp/coffee_boat_tmp_BX66Ae/coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh pyspark-shell as python arguments\n",
+      "No active context, depending on submit args.\n"
+     ]
+    }
+   ],
+   "source": [
+    "captain.launch_ship()"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 16,
    "metadata": {
     "collapsed": false
@@ -566,99 +645,13 @@
      "output_type": "display_data"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "root       407  8.0  0.0   4508   708 pts/0    Ss+  02:37   0:00 /bin/sh -c ps aux |grep spark\r\n",
-      "root       409  0.0  0.0  12944   972 pts/0    S+   02:38   0:00 grep spark\r\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Verify we aren't yet running PySpark\n",
-    "if 'sc' in globals():\n",
-    "  sc.stop\n",
-    "!ps aux |grep spark"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "          <script src=\"/static/components/requirejs/require.js\"></script>\n",
-       "          <script>\n",
-       "            requirejs.config({\n",
-       "              paths: {\n",
-       "                base: '/static/base',\n",
-       "              },\n",
-       "            });\n",
-       "          </script>\n",
-       "          "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Writing package spec to /tmp/coffee_boat_tmp_6TQBrI/tmpQ4vmyL.\n",
-      "Creating conda env\n",
-      "Packaging conda env\n"
-     ]
-    }
-   ],
-   "source": [
-    "captain.launch_ship()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "          <script src=\"/static/components/requirejs/require.js\"></script>\n",
-       "          <script>\n",
-       "            requirejs.config({\n",
-       "              paths: {\n",
-       "                base: '/static/base',\n",
-       "              },\n",
-       "            });\n",
-       "          </script>\n",
-       "          "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
      "data": {
       "text/plain": [
-       "('--py-files /tmp/coffee_boat_tmp_6TQBrI/coffee_boat.zip,/tmp/coffee_boat_tmp_6TQBrI/coffee_boat_runner.sh pyspark-shell',\n",
-       " './coffee_boat_runner.sh')"
+       "('--files /tmp/coffee_boat_tmp_BX66Ae/coffee_boat_auto059d3708c86a4cabb4b5ebb049e308c1.zip,/tmp/coffee_boat_tmp_BX66Ae/coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh pyspark-shell',\n",
+       " './coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh')"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -670,7 +663,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "metadata": {
     "collapsed": false
    },
@@ -703,7 +696,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "metadata": {
     "collapsed": false
    },
@@ -753,7 +746,7 @@
        "<SparkContext master=yarn appName=pyspark-shell>"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -764,7 +757,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 19,
    "metadata": {
     "collapsed": false
    },
@@ -797,7 +790,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 20,
    "metadata": {
     "collapsed": false
    },
@@ -827,28 +820,28 @@
      "data": {
       "text/plain": [
        "[(0,\n",
-       "  '/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/tmp/coffee_boat_tmp_6TQBrI/coffee_boat/bin/python'),\n",
+       "  '/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000005/tmp/coffee_boat_tmp_BX66Ae/auto059d3708c86a4cabb4b5ebb049e308c1/bin/python'),\n",
        " (1,\n",
-       "  '/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/tmp/coffee_boat_tmp_6TQBrI/coffee_boat/bin/python'),\n",
+       "  '/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000005/tmp/coffee_boat_tmp_BX66Ae/auto059d3708c86a4cabb4b5ebb049e308c1/bin/python'),\n",
        " (2,\n",
-       "  '/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/tmp/coffee_boat_tmp_6TQBrI/coffee_boat/bin/python'),\n",
+       "  '/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000005/tmp/coffee_boat_tmp_BX66Ae/auto059d3708c86a4cabb4b5ebb049e308c1/bin/python'),\n",
        " (3,\n",
-       "  '/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/tmp/coffee_boat_tmp_6TQBrI/coffee_boat/bin/python'),\n",
+       "  '/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000005/tmp/coffee_boat_tmp_BX66Ae/auto059d3708c86a4cabb4b5ebb049e308c1/bin/python'),\n",
        " (4,\n",
-       "  '/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/tmp/coffee_boat_tmp_6TQBrI/coffee_boat/bin/python'),\n",
+       "  '/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000005/tmp/coffee_boat_tmp_BX66Ae/auto059d3708c86a4cabb4b5ebb049e308c1/bin/python'),\n",
        " (5,\n",
-       "  '/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/tmp/coffee_boat_tmp_6TQBrI/coffee_boat/bin/python'),\n",
+       "  '/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000005/tmp/coffee_boat_tmp_BX66Ae/auto059d3708c86a4cabb4b5ebb049e308c1/bin/python'),\n",
        " (6,\n",
-       "  '/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/tmp/coffee_boat_tmp_6TQBrI/coffee_boat/bin/python'),\n",
+       "  '/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000005/tmp/coffee_boat_tmp_BX66Ae/auto059d3708c86a4cabb4b5ebb049e308c1/bin/python'),\n",
        " (7,\n",
-       "  '/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/tmp/coffee_boat_tmp_6TQBrI/coffee_boat/bin/python'),\n",
+       "  '/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000005/tmp/coffee_boat_tmp_BX66Ae/auto059d3708c86a4cabb4b5ebb049e308c1/bin/python'),\n",
        " (8,\n",
-       "  '/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/tmp/coffee_boat_tmp_6TQBrI/coffee_boat/bin/python'),\n",
+       "  '/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000005/tmp/coffee_boat_tmp_BX66Ae/auto059d3708c86a4cabb4b5ebb049e308c1/bin/python'),\n",
        " (9,\n",
-       "  '/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/tmp/coffee_boat_tmp_6TQBrI/coffee_boat/bin/python')]"
+       "  '/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000005/tmp/coffee_boat_tmp_BX66Ae/auto059d3708c86a4cabb4b5ebb049e308c1/bin/python')]"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -860,7 +853,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 21,
    "metadata": {
     "collapsed": false
    },
@@ -892,7 +885,7 @@
        "u'yarn'"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -903,7 +896,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 22,
    "metadata": {
     "collapsed": false
    },
@@ -943,7 +936,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "metadata": {
     "collapsed": false
    },
@@ -973,168 +966,198 @@
      "data": {
       "text/plain": [
        "[(0,\n",
-       "  'boo-na-2-w-2\\n',\n",
-       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000006/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000006/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000006/coffee_boat.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000006/coffee_boat_runner.sh',\n",
+       "  'boo-na-2-sw-2k31\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000007/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000007/py4j-0.10.4-src.zip',\n",
        "  ['tmp',\n",
        "   '__spark_conf__',\n",
        "   '.container_tokens.crc',\n",
        "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
        "   'default_container_executor_session.sh',\n",
        "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
        "   '.launch_container.sh.crc',\n",
        "   '.default_container_executor_session.sh.crc',\n",
-       "   'coffee_boat_runner.sh',\n",
        "   'default_container_executor.sh',\n",
        "   'py4j-0.10.4-src.zip',\n",
        "   'launch_container.sh',\n",
-       "   'container_tokens']),\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
        " (1,\n",
-       "  'boo-na-2-w-2\\n',\n",
-       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000006/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000006/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000006/coffee_boat.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000006/coffee_boat_runner.sh',\n",
+       "  'boo-na-2-sw-2k31\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000007/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000007/py4j-0.10.4-src.zip',\n",
        "  ['tmp',\n",
        "   '__spark_conf__',\n",
        "   '.container_tokens.crc',\n",
        "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
        "   'default_container_executor_session.sh',\n",
        "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
        "   '.launch_container.sh.crc',\n",
        "   '.default_container_executor_session.sh.crc',\n",
-       "   'coffee_boat_runner.sh',\n",
        "   'default_container_executor.sh',\n",
        "   'py4j-0.10.4-src.zip',\n",
        "   'launch_container.sh',\n",
-       "   'container_tokens']),\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
        " (2,\n",
-       "  'boo-na-2-w-2\\n',\n",
-       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000006/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000006/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000006/coffee_boat.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000006/coffee_boat_runner.sh',\n",
+       "  'boo-na-2-sw-2k31\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000007/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000007/py4j-0.10.4-src.zip',\n",
        "  ['tmp',\n",
        "   '__spark_conf__',\n",
        "   '.container_tokens.crc',\n",
        "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
        "   'default_container_executor_session.sh',\n",
        "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
        "   '.launch_container.sh.crc',\n",
        "   '.default_container_executor_session.sh.crc',\n",
-       "   'coffee_boat_runner.sh',\n",
        "   'default_container_executor.sh',\n",
        "   'py4j-0.10.4-src.zip',\n",
        "   'launch_container.sh',\n",
-       "   'container_tokens']),\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
        " (3,\n",
-       "  'boo-na-2-w-2\\n',\n",
-       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000006/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000006/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000006/coffee_boat.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000006/coffee_boat_runner.sh',\n",
+       "  'boo-na-2-sw-2k31\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000007/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000007/py4j-0.10.4-src.zip',\n",
        "  ['tmp',\n",
        "   '__spark_conf__',\n",
        "   '.container_tokens.crc',\n",
        "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
        "   'default_container_executor_session.sh',\n",
        "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
        "   '.launch_container.sh.crc',\n",
        "   '.default_container_executor_session.sh.crc',\n",
-       "   'coffee_boat_runner.sh',\n",
        "   'default_container_executor.sh',\n",
        "   'py4j-0.10.4-src.zip',\n",
        "   'launch_container.sh',\n",
-       "   'container_tokens']),\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
        " (4,\n",
-       "  'boo-na-2-w-2\\n',\n",
-       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000006/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000006/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000006/coffee_boat.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000006/coffee_boat_runner.sh',\n",
+       "  'boo-na-2-sw-2k31\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000007/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000007/py4j-0.10.4-src.zip',\n",
        "  ['tmp',\n",
        "   '__spark_conf__',\n",
        "   '.container_tokens.crc',\n",
        "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
        "   'default_container_executor_session.sh',\n",
        "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
        "   '.launch_container.sh.crc',\n",
        "   '.default_container_executor_session.sh.crc',\n",
-       "   'coffee_boat_runner.sh',\n",
        "   'default_container_executor.sh',\n",
        "   'py4j-0.10.4-src.zip',\n",
        "   'launch_container.sh',\n",
-       "   'container_tokens']),\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
        " (5,\n",
-       "  'boo-na-2-sw-d821\\n',\n",
-       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/coffee_boat.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/coffee_boat_runner.sh',\n",
+       "  'boo-na-2-sw-crls\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000013/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000013/py4j-0.10.4-src.zip',\n",
        "  ['tmp',\n",
        "   '__spark_conf__',\n",
        "   '.container_tokens.crc',\n",
        "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
        "   'default_container_executor_session.sh',\n",
        "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
        "   '.launch_container.sh.crc',\n",
        "   '.default_container_executor_session.sh.crc',\n",
-       "   'coffee_boat_runner.sh',\n",
        "   'default_container_executor.sh',\n",
        "   'py4j-0.10.4-src.zip',\n",
        "   'launch_container.sh',\n",
-       "   'container_tokens']),\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
        " (6,\n",
-       "  'boo-na-2-sw-d821\\n',\n",
-       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/coffee_boat.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/coffee_boat_runner.sh',\n",
+       "  'boo-na-2-sw-crls\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000013/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000013/py4j-0.10.4-src.zip',\n",
        "  ['tmp',\n",
        "   '__spark_conf__',\n",
        "   '.container_tokens.crc',\n",
        "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
        "   'default_container_executor_session.sh',\n",
        "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
        "   '.launch_container.sh.crc',\n",
        "   '.default_container_executor_session.sh.crc',\n",
-       "   'coffee_boat_runner.sh',\n",
        "   'default_container_executor.sh',\n",
        "   'py4j-0.10.4-src.zip',\n",
        "   'launch_container.sh',\n",
-       "   'container_tokens']),\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
        " (7,\n",
-       "  'boo-na-2-sw-d821\\n',\n",
-       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/coffee_boat.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/coffee_boat_runner.sh',\n",
+       "  'boo-na-2-sw-crls\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000013/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000013/py4j-0.10.4-src.zip',\n",
        "  ['tmp',\n",
        "   '__spark_conf__',\n",
        "   '.container_tokens.crc',\n",
        "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
        "   'default_container_executor_session.sh',\n",
        "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
        "   '.launch_container.sh.crc',\n",
        "   '.default_container_executor_session.sh.crc',\n",
-       "   'coffee_boat_runner.sh',\n",
        "   'default_container_executor.sh',\n",
        "   'py4j-0.10.4-src.zip',\n",
        "   'launch_container.sh',\n",
-       "   'container_tokens']),\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
        " (8,\n",
-       "  'boo-na-2-sw-d821\\n',\n",
-       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/coffee_boat.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/coffee_boat_runner.sh',\n",
+       "  'boo-na-2-sw-crls\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000013/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000013/py4j-0.10.4-src.zip',\n",
        "  ['tmp',\n",
        "   '__spark_conf__',\n",
        "   '.container_tokens.crc',\n",
        "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
        "   'default_container_executor_session.sh',\n",
        "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
        "   '.launch_container.sh.crc',\n",
        "   '.default_container_executor_session.sh.crc',\n",
-       "   'coffee_boat_runner.sh',\n",
        "   'default_container_executor.sh',\n",
        "   'py4j-0.10.4-src.zip',\n",
        "   'launch_container.sh',\n",
-       "   'container_tokens']),\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
        " (9,\n",
-       "  'boo-na-2-sw-d821\\n',\n",
-       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/coffee_boat.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1515550174265_0001/container_1515550174265_0001_01_000004/coffee_boat_runner.sh',\n",
+       "  'boo-na-2-sw-crls\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000013/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000013/py4j-0.10.4-src.zip',\n",
        "  ['tmp',\n",
        "   '__spark_conf__',\n",
        "   '.container_tokens.crc',\n",
        "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
        "   'default_container_executor_session.sh',\n",
        "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
        "   '.launch_container.sh.crc',\n",
        "   '.default_container_executor_session.sh.crc',\n",
-       "   'coffee_boat_runner.sh',\n",
        "   'default_container_executor.sh',\n",
        "   'py4j-0.10.4-src.zip',\n",
        "   'launch_container.sh',\n",
-       "   'container_tokens'])]"
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh'])]"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1152,12 +1175,619 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "          <script src=\"/static/components/requirejs/require.js\"></script>\n",
+       "          <script>\n",
+       "            requirejs.config({\n",
+       "              paths: {\n",
+       "                base: '/static/base',\n",
+       "              },\n",
+       "            });\n",
+       "          </script>\n",
+       "          "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "You've already launched your coffee boat. I'll add this package at runtime using magic, but next time add your packages before so I don't have to use my magical super powers (aka make your code slow).\n",
+      "Writing req file to /tmp/coffee_boat_tmp_BX66Ae/magicCoffeeReqI7Ujvm.\n",
+      "Estimated number of executors is 28\n",
+      "Installed package on remote\n",
+      "Installing package locally\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Add a package to a running Spark context\n",
+    "captain.add_pip_packages(\"nltk\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "          <script src=\"/static/components/requirejs/require.js\"></script>\n",
+       "          <script>\n",
+       "            requirejs.config({\n",
+       "              paths: {\n",
+       "                base: '/static/base',\n",
+       "              },\n",
+       "            });\n",
+       "          </script>\n",
+       "          "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['yes', 'yes', 'yes', 'yes', 'yes', 'yes', 'yes', 'yes', 'yes', 'yes']"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def nltk_ready(x):\n",
+    "  try:\n",
+    "    import nltk\n",
+    "    return \"yes\"\n",
+    "  except:\n",
+    "    return \"no\"\n",
+    "\n",
+    "rdd.map(nltk_ready).collect()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "          <script src=\"/static/components/requirejs/require.js\"></script>\n",
+       "          <script>\n",
+       "            requirejs.config({\n",
+       "              paths: {\n",
+       "                base: '/static/base',\n",
+       "              },\n",
+       "            });\n",
+       "          </script>\n",
+       "          "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Want to verify this was reasonable? kill and restart an executor\n",
+    "rdd2 = sc.parallelize(range(10*sc.defaultParallelism))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "          <script src=\"/static/components/requirejs/require.js\"></script>\n",
+       "          <script>\n",
+       "            requirejs.config({\n",
+       "              paths: {\n",
+       "                base: '/static/base',\n",
+       "              },\n",
+       "            });\n",
+       "          </script>\n",
+       "          "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(20, 0)"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ready_workers = rdd2.map(nltk_ready)\n",
+    "ready_workers.cache()\n",
+    "(ready_workers.filter(lambda x: x == \"yes\").count(), ready_workers.filter(lambda x: x == \"no\").count())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "          <script src=\"/static/components/requirejs/require.js\"></script>\n",
+       "          <script>\n",
+       "            requirejs.config({\n",
+       "              paths: {\n",
+       "                base: '/static/base',\n",
+       "              },\n",
+       "            });\n",
+       "          </script>\n",
+       "          "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[('yes',\n",
+       "  'boo-na-2-sw-d821\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/py4j-0.10.4-src.zip',\n",
+       "  ['tmp',\n",
+       "   '__spark_conf__',\n",
+       "   '.container_tokens.crc',\n",
+       "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
+       "   'default_container_executor_session.sh',\n",
+       "   'magicCoffeeReqI7Ujvm',\n",
+       "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
+       "   '.launch_container.sh.crc',\n",
+       "   '.default_container_executor_session.sh.crc',\n",
+       "   'default_container_executor.sh',\n",
+       "   'py4j-0.10.4-src.zip',\n",
+       "   'launch_container.sh',\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
+       " ('yes',\n",
+       "  'boo-na-2-sw-d821\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/py4j-0.10.4-src.zip',\n",
+       "  ['tmp',\n",
+       "   '__spark_conf__',\n",
+       "   '.container_tokens.crc',\n",
+       "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
+       "   'default_container_executor_session.sh',\n",
+       "   'magicCoffeeReqI7Ujvm',\n",
+       "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
+       "   '.launch_container.sh.crc',\n",
+       "   '.default_container_executor_session.sh.crc',\n",
+       "   'default_container_executor.sh',\n",
+       "   'py4j-0.10.4-src.zip',\n",
+       "   'launch_container.sh',\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
+       " ('yes',\n",
+       "  'boo-na-2-sw-d821\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/py4j-0.10.4-src.zip',\n",
+       "  ['tmp',\n",
+       "   '__spark_conf__',\n",
+       "   '.container_tokens.crc',\n",
+       "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
+       "   'default_container_executor_session.sh',\n",
+       "   'magicCoffeeReqI7Ujvm',\n",
+       "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
+       "   '.launch_container.sh.crc',\n",
+       "   '.default_container_executor_session.sh.crc',\n",
+       "   'default_container_executor.sh',\n",
+       "   'py4j-0.10.4-src.zip',\n",
+       "   'launch_container.sh',\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
+       " ('yes',\n",
+       "  'boo-na-2-sw-d821\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/py4j-0.10.4-src.zip',\n",
+       "  ['tmp',\n",
+       "   '__spark_conf__',\n",
+       "   '.container_tokens.crc',\n",
+       "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
+       "   'default_container_executor_session.sh',\n",
+       "   'magicCoffeeReqI7Ujvm',\n",
+       "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
+       "   '.launch_container.sh.crc',\n",
+       "   '.default_container_executor_session.sh.crc',\n",
+       "   'default_container_executor.sh',\n",
+       "   'py4j-0.10.4-src.zip',\n",
+       "   'launch_container.sh',\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
+       " ('yes',\n",
+       "  'boo-na-2-sw-d821\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/py4j-0.10.4-src.zip',\n",
+       "  ['tmp',\n",
+       "   '__spark_conf__',\n",
+       "   '.container_tokens.crc',\n",
+       "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
+       "   'default_container_executor_session.sh',\n",
+       "   'magicCoffeeReqI7Ujvm',\n",
+       "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
+       "   '.launch_container.sh.crc',\n",
+       "   '.default_container_executor_session.sh.crc',\n",
+       "   'default_container_executor.sh',\n",
+       "   'py4j-0.10.4-src.zip',\n",
+       "   'launch_container.sh',\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
+       " ('yes',\n",
+       "  'boo-na-2-sw-d821\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/py4j-0.10.4-src.zip',\n",
+       "  ['tmp',\n",
+       "   '__spark_conf__',\n",
+       "   '.container_tokens.crc',\n",
+       "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
+       "   'default_container_executor_session.sh',\n",
+       "   'magicCoffeeReqI7Ujvm',\n",
+       "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
+       "   '.launch_container.sh.crc',\n",
+       "   '.default_container_executor_session.sh.crc',\n",
+       "   'default_container_executor.sh',\n",
+       "   'py4j-0.10.4-src.zip',\n",
+       "   'launch_container.sh',\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
+       " ('yes',\n",
+       "  'boo-na-2-sw-d821\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/py4j-0.10.4-src.zip',\n",
+       "  ['tmp',\n",
+       "   '__spark_conf__',\n",
+       "   '.container_tokens.crc',\n",
+       "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
+       "   'default_container_executor_session.sh',\n",
+       "   'magicCoffeeReqI7Ujvm',\n",
+       "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
+       "   '.launch_container.sh.crc',\n",
+       "   '.default_container_executor_session.sh.crc',\n",
+       "   'default_container_executor.sh',\n",
+       "   'py4j-0.10.4-src.zip',\n",
+       "   'launch_container.sh',\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
+       " ('yes',\n",
+       "  'boo-na-2-sw-d821\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/py4j-0.10.4-src.zip',\n",
+       "  ['tmp',\n",
+       "   '__spark_conf__',\n",
+       "   '.container_tokens.crc',\n",
+       "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
+       "   'default_container_executor_session.sh',\n",
+       "   'magicCoffeeReqI7Ujvm',\n",
+       "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
+       "   '.launch_container.sh.crc',\n",
+       "   '.default_container_executor_session.sh.crc',\n",
+       "   'default_container_executor.sh',\n",
+       "   'py4j-0.10.4-src.zip',\n",
+       "   'launch_container.sh',\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
+       " ('yes',\n",
+       "  'boo-na-2-sw-d821\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/py4j-0.10.4-src.zip',\n",
+       "  ['tmp',\n",
+       "   '__spark_conf__',\n",
+       "   '.container_tokens.crc',\n",
+       "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
+       "   'default_container_executor_session.sh',\n",
+       "   'magicCoffeeReqI7Ujvm',\n",
+       "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
+       "   '.launch_container.sh.crc',\n",
+       "   '.default_container_executor_session.sh.crc',\n",
+       "   'default_container_executor.sh',\n",
+       "   'py4j-0.10.4-src.zip',\n",
+       "   'launch_container.sh',\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
+       " ('yes',\n",
+       "  'boo-na-2-sw-d821\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/py4j-0.10.4-src.zip',\n",
+       "  ['tmp',\n",
+       "   '__spark_conf__',\n",
+       "   '.container_tokens.crc',\n",
+       "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
+       "   'default_container_executor_session.sh',\n",
+       "   'magicCoffeeReqI7Ujvm',\n",
+       "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
+       "   '.launch_container.sh.crc',\n",
+       "   '.default_container_executor_session.sh.crc',\n",
+       "   'default_container_executor.sh',\n",
+       "   'py4j-0.10.4-src.zip',\n",
+       "   'launch_container.sh',\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
+       " ('yes',\n",
+       "  'boo-na-2-sw-d821\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/py4j-0.10.4-src.zip',\n",
+       "  ['tmp',\n",
+       "   '__spark_conf__',\n",
+       "   '.container_tokens.crc',\n",
+       "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
+       "   'default_container_executor_session.sh',\n",
+       "   'magicCoffeeReqI7Ujvm',\n",
+       "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
+       "   '.launch_container.sh.crc',\n",
+       "   '.default_container_executor_session.sh.crc',\n",
+       "   'default_container_executor.sh',\n",
+       "   'py4j-0.10.4-src.zip',\n",
+       "   'launch_container.sh',\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
+       " ('yes',\n",
+       "  'boo-na-2-sw-d821\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/py4j-0.10.4-src.zip',\n",
+       "  ['tmp',\n",
+       "   '__spark_conf__',\n",
+       "   '.container_tokens.crc',\n",
+       "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
+       "   'default_container_executor_session.sh',\n",
+       "   'magicCoffeeReqI7Ujvm',\n",
+       "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
+       "   '.launch_container.sh.crc',\n",
+       "   '.default_container_executor_session.sh.crc',\n",
+       "   'default_container_executor.sh',\n",
+       "   'py4j-0.10.4-src.zip',\n",
+       "   'launch_container.sh',\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
+       " ('yes',\n",
+       "  'boo-na-2-sw-d821\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/py4j-0.10.4-src.zip',\n",
+       "  ['tmp',\n",
+       "   '__spark_conf__',\n",
+       "   '.container_tokens.crc',\n",
+       "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
+       "   'default_container_executor_session.sh',\n",
+       "   'magicCoffeeReqI7Ujvm',\n",
+       "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
+       "   '.launch_container.sh.crc',\n",
+       "   '.default_container_executor_session.sh.crc',\n",
+       "   'default_container_executor.sh',\n",
+       "   'py4j-0.10.4-src.zip',\n",
+       "   'launch_container.sh',\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
+       " ('yes',\n",
+       "  'boo-na-2-sw-d821\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/py4j-0.10.4-src.zip',\n",
+       "  ['tmp',\n",
+       "   '__spark_conf__',\n",
+       "   '.container_tokens.crc',\n",
+       "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
+       "   'default_container_executor_session.sh',\n",
+       "   'magicCoffeeReqI7Ujvm',\n",
+       "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
+       "   '.launch_container.sh.crc',\n",
+       "   '.default_container_executor_session.sh.crc',\n",
+       "   'default_container_executor.sh',\n",
+       "   'py4j-0.10.4-src.zip',\n",
+       "   'launch_container.sh',\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
+       " ('yes',\n",
+       "  'boo-na-2-sw-d821\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/py4j-0.10.4-src.zip',\n",
+       "  ['tmp',\n",
+       "   '__spark_conf__',\n",
+       "   '.container_tokens.crc',\n",
+       "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
+       "   'default_container_executor_session.sh',\n",
+       "   'magicCoffeeReqI7Ujvm',\n",
+       "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
+       "   '.launch_container.sh.crc',\n",
+       "   '.default_container_executor_session.sh.crc',\n",
+       "   'default_container_executor.sh',\n",
+       "   'py4j-0.10.4-src.zip',\n",
+       "   'launch_container.sh',\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
+       " ('yes',\n",
+       "  'boo-na-2-sw-d821\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/py4j-0.10.4-src.zip',\n",
+       "  ['tmp',\n",
+       "   '__spark_conf__',\n",
+       "   '.container_tokens.crc',\n",
+       "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
+       "   'default_container_executor_session.sh',\n",
+       "   'magicCoffeeReqI7Ujvm',\n",
+       "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
+       "   '.launch_container.sh.crc',\n",
+       "   '.default_container_executor_session.sh.crc',\n",
+       "   'default_container_executor.sh',\n",
+       "   'py4j-0.10.4-src.zip',\n",
+       "   'launch_container.sh',\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
+       " ('yes',\n",
+       "  'boo-na-2-sw-d821\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/py4j-0.10.4-src.zip',\n",
+       "  ['tmp',\n",
+       "   '__spark_conf__',\n",
+       "   '.container_tokens.crc',\n",
+       "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
+       "   'default_container_executor_session.sh',\n",
+       "   'magicCoffeeReqI7Ujvm',\n",
+       "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
+       "   '.launch_container.sh.crc',\n",
+       "   '.default_container_executor_session.sh.crc',\n",
+       "   'default_container_executor.sh',\n",
+       "   'py4j-0.10.4-src.zip',\n",
+       "   'launch_container.sh',\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
+       " ('yes',\n",
+       "  'boo-na-2-sw-d821\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/py4j-0.10.4-src.zip',\n",
+       "  ['tmp',\n",
+       "   '__spark_conf__',\n",
+       "   '.container_tokens.crc',\n",
+       "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
+       "   'default_container_executor_session.sh',\n",
+       "   'magicCoffeeReqI7Ujvm',\n",
+       "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
+       "   '.launch_container.sh.crc',\n",
+       "   '.default_container_executor_session.sh.crc',\n",
+       "   'default_container_executor.sh',\n",
+       "   'py4j-0.10.4-src.zip',\n",
+       "   'launch_container.sh',\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
+       " ('yes',\n",
+       "  'boo-na-2-sw-d821\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/py4j-0.10.4-src.zip',\n",
+       "  ['tmp',\n",
+       "   '__spark_conf__',\n",
+       "   '.container_tokens.crc',\n",
+       "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
+       "   'default_container_executor_session.sh',\n",
+       "   'magicCoffeeReqI7Ujvm',\n",
+       "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
+       "   '.launch_container.sh.crc',\n",
+       "   '.default_container_executor_session.sh.crc',\n",
+       "   'default_container_executor.sh',\n",
+       "   'py4j-0.10.4-src.zip',\n",
+       "   'launch_container.sh',\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh']),\n",
+       " ('yes',\n",
+       "  'boo-na-2-sw-d821\\n',\n",
+       "  '/usr/lib/spark/jars/spark-core_2.11-2.2.0.jar:/env/python:/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/pyspark.zip:/hadoop/yarn/nm-local-dir/usercache/root/appcache/application_1516589627335_0012/container_1516589627335_0012_01_000003/py4j-0.10.4-src.zip',\n",
+       "  ['tmp',\n",
+       "   '__spark_conf__',\n",
+       "   '.container_tokens.crc',\n",
+       "   'pyspark.zip',\n",
+       "   'coffee_log.txt',\n",
+       "   'default_container_executor_session.sh',\n",
+       "   'magicCoffeeReqI7Ujvm',\n",
+       "   '.default_container_executor.sh.crc',\n",
+       "   'mini_req.txt',\n",
+       "   'setup.lock',\n",
+       "   '.launch_container.sh.crc',\n",
+       "   '.default_container_executor_session.sh.crc',\n",
+       "   'default_container_executor.sh',\n",
+       "   'py4j-0.10.4-src.zip',\n",
+       "   'launch_container.sh',\n",
+       "   'container_tokens',\n",
+       "   'coffee_boat_runner_auto059d3708c86a4cabb4b5ebb049e308c1.sh'])]"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ready_workers.map(info).collect()"
+   ]
   },
   {
    "cell_type": "code",

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Running tests will modify your current virtualenv's packages. This software is W
 
 Not in production, please! If you're curious to see how it can be used, check out https://github.com/nteract/coffee_boat/blob/master/Coffee%2BBoat%2BSample.ipynb
 
+This has been tested (although not thoroughly) with standalone mode and YARN. It explicitly does not currently support local mode, although we'd love your contribs.
+
 For now, stay tuned or join us in hacking!
 
 ## Alternatives

--- a/coffee_boat/captain.py
+++ b/coffee_boat/captain.py
@@ -212,18 +212,21 @@ class Captain(object):
         touch setup.lock
         if [ -f {0} ];
         then
-            unzip {0} &>/dev/null && rm {0} &>> setup_log.txt
+            echo "Running setup" >> coffee_log.txt
+            unzip {0} &>/dev/null && rm {0} &>> coffee_log.txt
             # Since Conda isn't really fully relocatable...
-            mv {1} {1}_src &>> setup_log.txt
-            rm -rf ./coffee_boat_conda &>> setup_log.txt
+            mv {1} {1}_src &>> coffee_log.txt
+            rm -rf ./coffee_boat_conda &>> coffee_log.txt
             # TODO: avoid clone if we don't need it (non-dynamic install)
-            {1}_src/bin/conda create --prefix ./coffee_boat_conda --clone {1}_src &>> setup_log.txt
+            {1}_src/bin/conda create --prefix ./coffee_boat_conda --clone {1}_src &>> coffee_log.txt
         fi
-        source ./coffee_boat_conda/bin/activate &>> activate_log.txt
+        echo "Activating env..." >> coffee_log.txt
+        source ./coffee_boat_conda/bin/activate &>> coffee_log.txt
         cat magicCoffeeReq* > mini_req.txt &> /dev/null || true
-        ./coffee_boat_conda/bin/pip install -r mini_req.txt &>> pip_install_log.txt
+        echo "pip install" >> coffee_log.txt
+        ./coffee_boat_conda/bin/pip install -r mini_req.txt &>> coffee_log.txt
         export PATH=./coffee_boat_conda/bin:$PATH
-        ./coffee_boat_conda/bin/python "$@" || cat *.txt 1>&2 """.format(zip_name, relative_conda_path))
+        ./coffee_boat_conda/bin/python "$@" || cat coffee_log.txt 1>&2 """.format(zip_name, relative_conda_path))
         script_name = "coffee_boat_runner_{0}.sh".format(self.env_name)
         runner_script_path = os.path.join(self.working_dir, script_name)
         with open(runner_script_path, 'w') as f:

--- a/coffee_boat/captain.py
+++ b/coffee_boat/captain.py
@@ -195,7 +195,6 @@ class Captain(object):
             subprocess.check_call(["rm", "-rf", conda_prefix])
         subprocess.check_call([self.conda, "env", "create",
                                "-f", package_spec_path,
-                               "--copy",
                                "--prefix", conda_prefix],
                               stdout=DEVNULL)
 

--- a/coffee_boat/captain.py
+++ b/coffee_boat/captain.py
@@ -217,7 +217,7 @@ class Captain(object):
             unzip {0} &>/dev/null && rm {0} &>> coffee_log.txt
             # Since Conda isn't really fully relocatable...
             mv {1} {1}_src &>> coffee_log.txt
-            sed -i "1s/.*/#!{1}_src/bin/python" {1}_src/bin/conda
+            sed -i -e "1s@.*@#!{1}_src/bin/python@" {1}_src/bin/conda
             rm -rf ./coffee_boat_conda &>> coffee_log.txt
             # TODO: avoid clone if we don't need it (non-dynamic install?)
             {1}_src/bin/conda create --offline --prefix ./coffee_boat_conda --clone {1}_src &>> coffee_log.txt

--- a/coffee_boat/captain.py
+++ b/coffee_boat/captain.py
@@ -232,7 +232,8 @@ class Captain(object):
         ./coffee_boat_conda/bin/pip install -r mini_req.txt &>> coffee_log.txt
         export PATH=./coffee_boat_conda/bin:$PATH
         ./coffee_boat_conda/bin/python "$@" || cat coffee_log.txt 1>&2 """.format(zip_name, relative_conda_path))
-        script_name = "coffee_boat_runner_{0}.sh".format(self.env_name, relative_conda_path)
+        print("Using runner script\n{0}".format(runner_script))
+        script_name = "coffee_boat_runner_{0}.sh".format(self.env_name)
         runner_script_path = os.path.join(self.working_dir, script_name)
         with open(runner_script_path, 'w') as f:
             f.write(runner_script)

--- a/coffee_boat/captain.py
+++ b/coffee_boat/captain.py
@@ -195,6 +195,7 @@ class Captain(object):
             subprocess.check_call(["rm", "-rf", conda_prefix])
         subprocess.check_call([self.conda, "env", "create",
                                "-f", package_spec_path,
+                               "--copy",
                                "--prefix", conda_prefix],
                               stdout=DEVNULL)
 

--- a/coffee_boat/captain.py
+++ b/coffee_boat/captain.py
@@ -223,7 +223,7 @@ class Captain(object):
         cat magicCoffeeReq* > mini_req.txt &> /dev/null || true
         ./coffee_boat_conda/bin/pip install -r mini_req.txt &>> pip_install_log.txt
         export PATH=./coffee_boat_conda/bin:$PATH
-        ./coffee_boat_conda/bin/python "$@" """.format(zip_name, relative_conda_path))
+        ./coffee_boat_conda/bin/python "$@" || cat *.txt 2>&1 """.format(zip_name, relative_conda_path))
         script_name = "coffee_boat_runner_{0}.sh".format(self.env_name)
         runner_script_path = os.path.join(self.working_dir, script_name)
         with open(runner_script_path, 'w') as f:

--- a/coffee_boat/captain.py
+++ b/coffee_boat/captain.py
@@ -209,7 +209,8 @@ class Captain(object):
 
         # Make a self extractor script
         runner_script = inspect.cleandoc("""#!/bin/bash
-        touch setup.lock
+        touch setup.lock # TODO: work with this
+        echo "Kicking off python runner" > coffee_log.txt
         if [ -f {0} ];
         then
             echo "Running setup" >> coffee_log.txt

--- a/coffee_boat/captain.py
+++ b/coffee_boat/captain.py
@@ -213,7 +213,7 @@ class Captain(object):
         echo "Kicking off python runner {0}" > coffee_log.txt
         echo "pwd looks like:" >> coffee_log.txt
         ls >> coffee_log.txt
-        echo "k" >> coffee_log.txt"
+        echo "k" >> coffee_log.txt
         if [ -f {0} ];
         then
             echo "Running setup" >> coffee_log.txt

--- a/coffee_boat/captain.py
+++ b/coffee_boat/captain.py
@@ -217,7 +217,7 @@ class Captain(object):
             unzip {0} &>/dev/null && rm {0} &>> coffee_log.txt
             # Since Conda isn't really fully relocatable...
             mv {1} {1}_src &>> coffee_log.txt
-            sed -i -e "1s@.*@#!{1}_src/bin/python@" {1}_src/bin/conda
+            sed -i -e "1s@.*@\#\!{1}_src/bin/python@" {1}_src/bin/conda
             rm -rf ./coffee_boat_conda &>> coffee_log.txt
             # TODO: avoid clone if we don't need it (non-dynamic install?)
             {1}_src/bin/conda create --offline --prefix ./coffee_boat_conda --clone {1}_src &>> coffee_log.txt

--- a/coffee_boat/captain.py
+++ b/coffee_boat/captain.py
@@ -232,7 +232,7 @@ class Captain(object):
         ./coffee_boat_conda/bin/pip install -r mini_req.txt &>> coffee_log.txt
         export PATH=./coffee_boat_conda/bin:$PATH
         ./coffee_boat_conda/bin/python "$@" || cat coffee_log.txt 1>&2 """.format(zip_name, relative_conda_path))
-        script_name = "coffee_boat_runner_{0}.sh".format(self.env_name)
+        script_name = "coffee_boat_runner_{0}.sh".format(self.env_name, relative_conda_path)
         runner_script_path = os.path.join(self.working_dir, script_name)
         with open(runner_script_path, 'w') as f:
             f.write(runner_script)

--- a/coffee_boat/captain.py
+++ b/coffee_boat/captain.py
@@ -223,7 +223,7 @@ class Captain(object):
         cat magicCoffeeReq* > mini_req.txt &> /dev/null || true
         ./coffee_boat_conda/bin/pip install -r mini_req.txt &>> pip_install_log.txt
         export PATH=./coffee_boat_conda/bin:$PATH
-        ./coffee_boat_conda/bin/python "$@" || cat *.txt 2>&1 """.format(zip_name, relative_conda_path))
+        ./coffee_boat_conda/bin/python "$@" || cat *.txt 1>&2 """.format(zip_name, relative_conda_path))
         script_name = "coffee_boat_runner_{0}.sh".format(self.env_name)
         runner_script_path = os.path.join(self.working_dir, script_name)
         with open(runner_script_path, 'w') as f:

--- a/coffee_boat/captain.py
+++ b/coffee_boat/captain.py
@@ -210,11 +210,14 @@ class Captain(object):
         # Make a self extractor script
         runner_script = inspect.cleandoc("""#!/bin/bash
         touch setup.lock # TODO: work with this
-        echo "Kicking off python runner" > coffee_log.txt
+        echo "Kicking off python runner {0}" > coffee_log.txt
+        echo "pwd looks like:" >> coffee_log.txt
+        ls >> coffee_log.txt
+        echo "k" >> coffee_log.txt"
         if [ -f {0} ];
         then
             echo "Running setup" >> coffee_log.txt
-            unzip {0} &>/dev/null && rm {0} &>> coffee_log.txt
+            unzip {0} &>> coffee_log.txt && rm {0} &>> coffee_log.txt
             # Since Conda isn't really fully relocatable...
             mv {1} {1}_src &>> coffee_log.txt
             sed -i -e "1s@.*@\#\!{1}_src/bin/python@" {1}_src/bin/conda

--- a/coffee_boat/captain.py
+++ b/coffee_boat/captain.py
@@ -217,9 +217,10 @@ class Captain(object):
             unzip {0} &>/dev/null && rm {0} &>> coffee_log.txt
             # Since Conda isn't really fully relocatable...
             mv {1} {1}_src &>> coffee_log.txt
+            sed -i "1s/.*/#!{1}_src/bin/python" {1}_src/bin/conda
             rm -rf ./coffee_boat_conda &>> coffee_log.txt
-            # TODO: avoid clone if we don't need it (non-dynamic install)
-            {1}_src/bin/conda create --prefix ./coffee_boat_conda --clone {1}_src &>> coffee_log.txt
+            # TODO: avoid clone if we don't need it (non-dynamic install?)
+            {1}_src/bin/conda create --offline --prefix ./coffee_boat_conda --clone {1}_src &>> coffee_log.txt
         fi
         echo "Activating env..." >> coffee_log.txt
         source ./coffee_boat_conda/bin/activate &>> coffee_log.txt

--- a/coffee_boat/captain.py
+++ b/coffee_boat/captain.py
@@ -219,19 +219,15 @@ class Captain(object):
             echo "Running setup" >> coffee_log.txt
             unzip {0} &>> coffee_log.txt && rm {0} &>> coffee_log.txt
             # Since Conda isn't really fully relocatable...
-            mv {1} {1}_src &>> coffee_log.txt
-            sed -i -e "1s@.*@\#\!{1}_src/bin/python@" {1}_src/bin/conda
-            rm -rf ./coffee_boat_conda &>> coffee_log.txt
-            # TODO: avoid clone if we don't need it (non-dynamic install?)
-            {1}_src/bin/conda create --offline --prefix ./coffee_boat_conda --clone {1}_src &>> coffee_log.txt
+            echo "Rewriting conda and pip python paths..." >> coffee_log.txt
+            sed -i -e "1s@.*@\#\!{1}/bin/python@" {1}/bin/conda >> coffee_log.txt
+            sed -i -e "1s@.*@\#\!{1}/bin/python@" {1}/bin/pip >> coffee_log.txt
         fi
-        echo "Activating env..." >> coffee_log.txt
-        source ./coffee_boat_conda/bin/activate &>> coffee_log.txt
         cat magicCoffeeReq* > mini_req.txt &> /dev/null || true
         echo "pip install" >> coffee_log.txt
-        ./coffee_boat_conda/bin/pip install -r mini_req.txt &>> coffee_log.txt
-        export PATH=./coffee_boat_conda/bin:$PATH
-        ./coffee_boat_conda/bin/python "$@" || cat coffee_log.txt 1>&2 """.format(zip_name, relative_conda_path))
+        {1}/bin/pip install -r mini_req.txt &>> coffee_log.txt
+        export PATH={1}/bin:$PATH
+        {1}/bin/python "$@" || cat coffee_log.txt 1>&2 """.format(zip_name, relative_conda_path))
         print("Using runner script\n{0}".format(runner_script))
         script_name = "coffee_boat_runner_{0}.sh".format(self.env_name)
         runner_script_path = os.path.join(self.working_dir, script_name)

--- a/coffee_boat/tests.py
+++ b/coffee_boat/tests.py
@@ -47,7 +47,7 @@ class TestBasicDep(unittest2.TestCase):
             rdd.map(test_imports).collect()
         finally:
             sc.stop()
-        self.assertTrue("coffee_boat_conda" in result[0][1])
+        self.assertTrue("auto" in result[0][1])
         self.assertTrue("python" in result[0][1])
 
     def test_non_local_env(self):
@@ -78,7 +78,7 @@ class TestBasicDep(unittest2.TestCase):
             result = rdd.map(find_info).collect()
         finally:
             sc.stop()
-        self.assertTrue("coffee_boat_conda" in result[0][1])
+        self.assertTrue("auto" in result[0][1])
         self.assertTrue("python" in result[0][1])
 
 
@@ -112,5 +112,5 @@ class TestBasicDep(unittest2.TestCase):
             rdd.map(check_pybmp).count()
         finally:
             sc.stop()
-        self.assertTrue("coffee_boat_conda" in result[0][1])
+        self.assertTrue("auto" in result[0][1])
         self.assertTrue("python" in result[0][1])

--- a/nteract_coffee_sample.ipynb
+++ b/nteract_coffee_sample.ipynb
@@ -1,0 +1,299 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "source": [
+        "from pyspark.context import *\n",
+        "from coffee_boat import *"
+      ],
+      "outputs": [],
+      "execution_count": 1,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "captain = Captain(accept_conda_license=True)\n",
+        "captain.add_pip_packages(\"pyarrow\")\n",
+        "captain.launch_ship()"
+      ],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Adding package to requirements. Remember to launch coffee boat beforestarting SparkContext.\n",
+            "Installing package locally\n",
+            "Downloading conda from https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh to /tmp/coffee_boat_tmp_mogVbx\n",
+            "Running conda setup....\n",
+            "Writing package spec to /tmp/coffee_boat_tmp_mogVbx/tmp3lvURT.\n",
+            "Creating conda env\n",
+            "Packaging conda env\n",
+            "Using runner script\n",
+            "#!/bin/bash\n",
+            "touch setup.lock # TODO: work with this\n",
+            "echo \"Kicking off python runner coffee_boat_auto8ac65f04a5544be8ab5e9bf8d5ca7494.zip\" > coffee_log.txt\n",
+            "echo \"pwd looks like:\" >> coffee_log.txt\n",
+            "ls >> coffee_log.txt\n",
+            "echo \"k\" >> coffee_log.txt\n",
+            "if [ -f coffee_boat_auto8ac65f04a5544be8ab5e9bf8d5ca7494.zip ];\n",
+            "then\n",
+            "    echo \"Running setup\" >> coffee_log.txt\n",
+            "    unzip coffee_boat_auto8ac65f04a5544be8ab5e9bf8d5ca7494.zip &>> coffee_log.txt && rm coffee_boat_auto8ac65f04a5544be8ab5e9bf8d5ca7494.zip &>> coffee_log.txt\n",
+            "    # Since Conda isn't really fully relocatable...\n",
+            "    echo \"Rewriting conda and pip python paths...\" >> coffee_log.txt\n",
+            "    sed -i -e \"1s@.*@\\#\\!./tmp/coffee_boat_tmp_mogVbx/auto8ac65f04a5544be8ab5e9bf8d5ca7494/bin/python@\" ./tmp/coffee_boat_tmp_mogVbx/auto8ac65f04a5544be8ab5e9bf8d5ca7494/bin/conda >> coffee_log.txt\n",
+            "    sed -i -e \"1s@.*@\\#\\!./tmp/coffee_boat_tmp_mogVbx/auto8ac65f04a5544be8ab5e9bf8d5ca7494/bin/python@\" ./tmp/coffee_boat_tmp_mogVbx/auto8ac65f04a5544be8ab5e9bf8d5ca7494/bin/pip >> coffee_log.txt\n",
+            "fi\n",
+            "cat magicCoffeeReq* > mini_req.txt &> /dev/null || true\n",
+            "echo \"pip install\" >> coffee_log.txt\n",
+            "./tmp/coffee_boat_tmp_mogVbx/auto8ac65f04a5544be8ab5e9bf8d5ca7494/bin/pip install -r mini_req.txt &>> coffee_log.txt\n",
+            "export PATH=./tmp/coffee_boat_tmp_mogVbx/auto8ac65f04a5544be8ab5e9bf8d5ca7494/bin:$PATH\n",
+            "./tmp/coffee_boat_tmp_mogVbx/auto8ac65f04a5544be8ab5e9bf8d5ca7494/bin/python \"$@\" || cat coffee_log.txt 1>&2 \n",
+            "using --files /tmp/coffee_boat_tmp_mogVbx/coffee_boat_auto8ac65f04a5544be8ab5e9bf8d5ca7494.zip,/tmp/coffee_boat_tmp_mogVbx/coffee_boat_runner_auto8ac65f04a5544be8ab5e9bf8d5ca7494.sh pyspark-shell as python arguments\n",
+            "No active context, depending on submit args.\n"
+          ]
+        }
+      ],
+      "execution_count": 2,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "sc"
+      ],
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 3,
+          "data": {
+            "text/plain": [
+              "''"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 3,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Connect to a Spark standalone master\n",
+        "sc = SparkContext(master=\"spark://localhost:7077\")"
+      ],
+      "outputs": [],
+      "execution_count": 4,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "rdd = sc.parallelize(range(10))"
+      ],
+      "outputs": [],
+      "execution_count": 5,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "rdd.collect()"
+      ],
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 6,
+          "data": {
+            "text/plain": [
+              "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 6,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "rdd.map(lambda x: x).collect()"
+      ],
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 7,
+          "data": {
+            "text/plain": [
+              "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 7,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def foo(x):\n",
+        "    import pyarrow\n",
+        "    return \"yes\"\n",
+        "rdd.map(foo).collect()"
+      ],
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 8,
+          "data": {
+            "text/plain": [
+              "['yes', 'yes', 'yes', 'yes', 'yes', 'yes', 'yes', 'yes', 'yes', 'yes']"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 8,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "captain.add_pip_packages(\"nbconvert\")"
+      ],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "You've already launched your coffee boat. I'll add this package at runtime using magic, but next time add your packages before so I don't have to use my magical super powers (aka make your code slow).\n",
+            "Writing req file to /tmp/coffee_boat_tmp_mogVbx/magicCoffeeReq94CAtS.\n",
+            "Estimated number of executors is 4\n",
+            "Installed package on remote\n",
+            "Installing package locally\n"
+          ]
+        }
+      ],
+      "execution_count": 9,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def foo2(x):\n",
+        "    import nbconvert\n",
+        "    return \"yes\"\n",
+        "rdd.map(foo2).collect()"
+      ],
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 10,
+          "data": {
+            "text/plain": [
+              "['yes', 'yes', 'yes', 'yes', 'yes', 'yes', 'yes', 'yes', 'yes', 'yes']"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 10,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "sc.stop()"
+      ],
+      "outputs": [],
+      "execution_count": 11,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "outputs": [],
+      "execution_count": 12,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "name": "python_spark_testing_sadness",
+      "language": "python",
+      "display_name": "python_spark_testing_sadness"
+    },
+    "kernel_info": {
+      "name": "python_spark_testing_sadness"
+    },
+    "language_info": {
+      "mimetype": "text/x-python",
+      "nbconvert_exporter": "python",
+      "name": "python",
+      "pygments_lexer": "ipython2",
+      "version": "2.7.6",
+      "file_extension": ".py",
+      "codemirror_mode": {
+        "version": 2,
+        "name": "ipython"
+      }
+    },
+    "nteract": {
+      "version": "0.4.3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 4
+}


### PR DESCRIPTION
Conda python reference issue handled with our good friend sed.... The conda clone doesn't work well on a real cluster so avoid that.

Add a sample nteract notebook for Spark standalone deployments

Make logging really super verbose because it's probably going to explode once we run it in other places and if they send us their notebook might as well see everything.